### PR TITLE
Upgrade Django 3 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Django>=3.1
+Django>=3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Django>=1.5
+Django>=3.1

--- a/sky_visitor/__init__.py
+++ b/sky_visitor/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = (2, 0, 3)
+__version__ = (2, 0, 4)

--- a/sky_visitor/__init__.py
+++ b/sky_visitor/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = (2, 0, 4)
+__version__ = (2, 1, 0)

--- a/sky_visitor/forms/__init__.py
+++ b/sky_visitor/forms/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.auth import forms as auth_forms, get_user_model
 from sky_visitor.forms.fields import PasswordRulesField
 from sky_visitor.models import InvitedUser

--- a/sky_visitor/urls.py
+++ b/sky_visitor/urls.py
@@ -11,20 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from django.conf.urls import *
+from django.urls import re_path
 from sky_visitor.views import *
 
 TOKEN_REGEX = '(?P<uidb36>[0-9A-Za-z]{1,13})-(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})'
 
 urlpatterns = [
-    url(r'^register/$', RegisterView.as_view(), name='register'),
-    url(r'^login/$', LoginView.as_view(), name='login'),
-    url(r'^logout/$', LogoutView.as_view(), name='logout'),
-    url(r'^forgot_password/$', ForgotPasswordView.as_view(), name='forgot_password'),
-    url(r'^forgot_password/check_email/$', ForgotPasswordCheckEmailView.as_view(), name='forgot_password_check_email'),
-    url(r'^reset_password/%s/$' % TOKEN_REGEX, ResetPasswordView.as_view(), name='reset_password'),
-    url(r'^change_password/$', ChangePasswordView.as_view(), name='change_password'),
-    url(r'invitation/$', InvitationStartView.as_view(), name='invitation_start'),
-    url(r'invitation/%s/$' % TOKEN_REGEX, InvitationCompleteView.as_view(), name='invitation_complete'),
-#     url(r'invitation/done/$',   InvitationDoneView.as_view(),   name='invitation_done'),
+    re_path(r'^register/$', RegisterView.as_view(), name='register'),
+    re_path(r'^login/$', LoginView.as_view(), name='login'),
+    re_path(r'^logout/$', LogoutView.as_view(), name='logout'),
+    re_path(r'^forgot_password/$', ForgotPasswordView.as_view(), name='forgot_password'),
+    re_path(r'^forgot_password/check_email/$', ForgotPasswordCheckEmailView.as_view(), name='forgot_password_check_email'),
+    re_path(r'^reset_password/%s/$' % TOKEN_REGEX, ResetPasswordView.as_view(), name='reset_password'),
+    re_path(r'^change_password/$', ChangePasswordView.as_view(), name='change_password'),
+    re_path(r'invitation/$', InvitationStartView.as_view(), name='invitation_start'),
+    re_path(r'invitation/%s/$' % TOKEN_REGEX, InvitationCompleteView.as_view(), name='invitation_complete'),
+#     re_path(r'invitation/done/$',   InvitationDoneView.as_view(),   name='invitation_done'),
 ]

--- a/sky_visitor/views/__init__.py
+++ b/sky_visitor/views/__init__.py
@@ -19,11 +19,11 @@ from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import resolve_url
 from django.utils.decorators import method_decorator
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect
 from django.views.generic import CreateView, FormView, RedirectView, TemplateView
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from sky_visitor.models import InvitedUser
 from sky_visitor.backends import auto_login
 from sky_visitor.forms import RegisterForm, LoginForm, PasswordResetForm, SetPasswordForm, PasswordChangeForm, InvitationStartForm, InvitationCompleteForm
@@ -88,7 +88,7 @@ class LoginView(FormView):
         redirect_to = self.request.GET.get(self.redirect_field_name, '')
 
         # Ensure the user-originating redirection url is safe.
-        if not is_safe_url(url=redirect_to, host=self.request.get_host()):
+        if not url_has_allowed_host_and_scheme(url=redirect_to, allowed_hosts={self.request.get_host()}):
             redirect_to = resolve_url(settings.LOGIN_REDIRECT_URL)
 
         if self.success_url and (self.success_url_overrides_redirect_field or not redirect_to):
@@ -152,7 +152,7 @@ class LogoutView(RedirectView):
         if self.redirect_field_name in self.request.GET:
             redirect_to = self.request.GET[self.redirect_field_name]
             # Security check -- don't allow redirection to a different host.
-            if not is_safe_url(url=redirect_to, host=self.request.get_host()):
+            if not url_has_allowed_host_and_scheme(url=redirect_to, allowed_hosts={self.request.get_host()}):
                 redirect_to = self.request.path
 
         return redirect_to

--- a/sky_visitor/views/mixins.py
+++ b/sky_visitor/views/mixins.py
@@ -24,7 +24,7 @@ from django.shortcuts import resolve_url
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
 from django.utils.http import base36_to_int, int_to_base36
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from emailtemplates.utils import send_email_template
 


### PR DESCRIPTION
## Description 

In Django 4 were removed already deprecated methods like

1. `uggettext()` was replaced with `gettext()`
2. `url()` was replaced with path and `re_path()`
3. `is_safe_url()` is replaced with `url_has_allowed_host_and_scheme()`

So it makes sense to update packages in order to fit our project